### PR TITLE
Add GHA Workflows

### DIFF
--- a/.github/workflows/prod-promote.yml
+++ b/.github/workflows/prod-promote.yml
@@ -1,0 +1,21 @@
+### This is the Terraform-generated prod-promote.yml workflow for the browsertrix-harvester-prod repository. ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document.         ###
+name: Prod Container Promote
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    name: Prod Container Promote
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-promote-prod.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE_STAGE: browsertrix-harvester-gha-stage
+      GHA_ROLE_PROD: browsertrix-harvester-gha-prod
+      ECR_STAGE: "browsertrix-harvester-stage"
+      ECR_PROD: "browsertrix-harvester-prod"
+      # FUNCTION: ""
+ 

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -1,0 +1,24 @@
+### This is the Terraform-generated dev-build.yml workflow for the browsertrix-harvester-stage app repository ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document     ###
+### If the container requires any additional pre-build commands, uncomment and edit      ###
+### the PREBUILD line at the end of the document.                                        ###
+name: Stage Container Build and Deploy
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  deploy:
+    name: Stage Container Deploy
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-stage.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE: "browsertrix-harvester-gha-stage"
+      ECR: "browsertrix-harvester-stage"
+      # FUNCTION: ""
+      # PREBUILD: 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+### This is the Terraform-generated header for browsertrix-harvester-dev. If  ###
+###   this is a Lambda repo, uncomment the FUNCTION line below  ###
+###   and review the other commented lines in the document.     ###
+ECR_NAME_DEV:=browsertrix-harvester-dev
+ECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/browsertrix-harvester-dev
+### End of Terraform-generated header                            ###
 SHELL=/bin/bash
 DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
 
@@ -56,14 +62,6 @@ test-crawl-homepage:
 build-docker:
 	docker build --platform linux/arm64 -t $(ECR_NAME_DEV):latest .
 
-### This is the Terraform-generated header for browsertrix-harvester-dev. If  ###
-###   this is a Lambda repo, uncomment the FUNCTION line below  ###
-###   and review the other commented lines in the document.     ###
-ECR_NAME_DEV:=browsertrix-harvester-dev
-ECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/browsertrix-harvester-dev
-# FUNCTION_DEV:=
-### End of Terraform-generated header                            ###
-
 ### Terraform-generated Developer Deploy Commands for Dev environment ###
 dist-dev: ## Build docker container (intended for developer-based manual build)
 	docker build --platform linux/amd64 \
@@ -75,11 +73,6 @@ publish-dev: dist-dev ## Build, tag and push (intended for developer-based manua
 	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_DEV)
 	docker push $(ECR_URL_DEV):latest
 	docker push $(ECR_URL_DEV):`git describe --always`
-
-### If this is a Lambda repo, uncomment the two lines below     ###
-# update-lambda-dev: ## Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
-#	aws lambda update-function-code --function-name $(FUNCTION_DEV) --image-uri $(ECR_URL_DEV):latest
-
 
 ### Terraform-generated manual shortcuts for deploying to Stage. This requires  ###
 ###   that ECR_NAME_STAGE, ECR_URL_STAGE, and FUNCTION_STAGE environment        ###
@@ -96,7 +89,3 @@ publish-stage: ## Only use in an emergency
 	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_STAGE)
 	docker push $(ECR_URL_STAGE):latest
 	docker push $(ECR_URL_STAGE):`git describe --always`
-
-### If this is a Lambda repo, uncomment the two lines below     ###
-# update-lambda-stage: ## Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
-#	aws lambda update-function-code --function-name $(FUNCTION_STAGE) --image-uri $(ECR_URL_STAGE):latest


### PR DESCRIPTION
Why these changes are being introduced:
The ECR repositories have been deployed in all three environments in AWS. This updates the app repo with the associated deployment automation workflows.

How this addresses that need:
* Add the `stage-build` workflow from the mitlib-tf-workloads-ecr repo
* Add the `prod-promote` workflow from the mitlib-tf-workloads-ecr repo
* Minor formatting changes to the Makefile (to put the Tf-generated header at the top of the file)

Side effects of this change:
Merges to the `main` branch will now automatically deploy to Stage-Workloads. Tagged releases on the `main` branch will automatically deploy to Prod-Workloads.

Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/TIMX-248
