### PR TITLE
Add web crawl capabilities to harvester app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,12 @@ shell:
 # Docker commands
 dist-local:
 	docker build -t $(ECR_NAME_DEV):latest .
+
+# Test crawl commands
+# local docker container crawl
+test-harvest-local:
+	pipenv run harvest-dockerized --verbose harvest \
+	--crawl-name="homepage" \
+	--config-yaml-file="/browsertrix-harvester/tests/fixtures/lib-website-homepage.yaml" \
+	--num-workers 4 \
+	--btrix-args-json='{"--maxPageLimit":"15"}'

--- a/README.md
+++ b/README.md
@@ -109,27 +109,23 @@ Usage: -c harvest [OPTIONS]
   Perform a web crawl and parse structured data.
 
 Options:
-  --crawl-name TEXT            Name of crawl  [required]
-  --config-yaml-file TEXT      Filepath of browsertrix config YAML. Can be a
-                               local filepath or an S3 URI, e.g.
-                               s3://bucketname/crawl-config.yaml  [required]
-  --sitemap-from-date TEXT     YYYY-MM-DD string to filter websites modified
-                               after this date in sitemaps
-  --wacz-output-file TEXT      Filepath to write WACZ archive file to. Can be
-                               a local filepath or an S3 URI, e.g.
-                               s3://bucketname/filename.xml.
-  --metadata-output-file TEXT  Filepath to write metadata records to. Can be a
-                               local filepath or an S3 URI, e.g.
-                               s3://bucketname/filename.wacz.
-  --include-fulltext           Set to include parsed fulltext from website in
-                               generated structured metadata. [Default False]
-  --num-workers INTEGER        Number of parallel thread workers for crawler.
-                               [Default 2]
-  --btrix-args-json TEXT       JSON formatted string of additional args to
-                               pass to browsertrix-crawler,
-                               https://github.com/webrecorder/browsertrix-
-                               crawler#crawling-configuration-options
-  -h, --help                   Show this message and exit.
+  --config-yaml-file TEXT   Filepath of browsertrix config YAML. Can be a
+                            local filepath or an S3 URI, e.g.
+                            s3://bucketname/crawl-config.yaml  [required]
+  --crawl-name TEXT         Optional override for crawl name. [Default
+                            'crawl-<TIMESTAMP>']
+  --sitemap-from-date TEXT  YYYY-MM-DD string to filter websites modified
+                            after this date in sitemaps
+  --wacz-output-file TEXT   Filepath to write WACZ archive file to. Can be a
+                            local filepath or an S3 URI, e.g.
+                            s3://bucketname/filename.xml.
+  --num-workers INTEGER     Number of parallel thread workers for crawler.
+                            [Default 2]
+  --btrix-args-json TEXT    JSON formatted string of additional args to pass
+                            to browsertrix-crawler,
+                            https://github.com/webrecorder/browsertrix-
+                            crawler#crawling-configuration-options
+  -h, --help                Show this message and exit.
 ```
     
 ## Browsertrix Crawl Configuration

--- a/README.md
+++ b/README.md
@@ -88,3 +88,108 @@ Usage: -c shell [OPTIONS]
 Options:
   -h, --help            Show this message and exit.
 ```
+
+### Perform web crawl and harvest data
+This is the primary command for this application.  This performs a web crawl, then optionally parses the results of that crawl into structured data and writes to a specific location.
+
+See section [Browsertrix Crawl Configuration](#browsertrix-crawl-configuration) for details about configuring the browsertrix crawl part of a harvest.
+
+**NOTE:** if neither `--wacz-output-file` or `--metadata-output-file` is set, a crawl will be performed, but nothing will exist outside of the container after it completes.
+
+```shell
+# run harvest as local docker container
+pipenv run harvest-dockerized harvest
+
+# command used for deployed ECS task
+pipenv run harvest harvest
+```
+```text
+Usage: -c harvest [OPTIONS]
+
+  Perform a web crawl and parse structured data.
+
+Options:
+  --crawl-name TEXT            Name of crawl  [required]
+  --config-yaml-file TEXT      Filepath of browsertrix config YAML. Can be a
+                               local filepath or an S3 URI, e.g.
+                               s3://bucketname/crawl-config.yaml  [required]
+  --sitemap-from-date TEXT     YYYY-MM-DD string to filter websites modified
+                               after this date in sitemaps
+  --wacz-output-file TEXT      Filepath to write WACZ archive file to. Can be
+                               a local filepath or an S3 URI, e.g.
+                               s3://bucketname/filename.xml.
+  --metadata-output-file TEXT  Filepath to write metadata records to. Can be a
+                               local filepath or an S3 URI, e.g.
+                               s3://bucketname/filename.wacz.
+  --include-fulltext           Set to include parsed fulltext from website in
+                               generated structured metadata. [Default False]
+  --num-workers INTEGER        Number of parallel thread workers for crawler.
+                               [Default 2]
+  --btrix-args-json TEXT       JSON formatted string of additional args to
+                               pass to browsertrix-crawler,
+                               https://github.com/webrecorder/browsertrix-
+                               crawler#crawling-configuration-options
+  -h, --help                   Show this message and exit.
+```
+    
+## Browsertrix Crawl Configuration
+
+A layered approach is used for configuring the browsertrix crawl part:
+1. defaults defined in `Crawler` class that initialize the base crawler command
+2. configuration YAML file read and applied by the crawler
+3. runtime CLI arguments for this app that override a subset of defaults or YAML defined configurations
+
+Ultimately, these combine to provide the crawler configurations defined here: https://github.com/webrecorder/browsertrix-crawler#crawling-configuration-options.
+
+### Why this approach?
+
+Some arguments are required (e.g. generating CDX index, generating a WACZ archive, etc.) for this harvester to work with the crawl results and therefore set as defaults, some are complex to define as command line arguments (e.g. seeds and exclusion patterns), and some are commonly overriden at runtime (e.g. last modified date for URLs to include).
+
+It is expected that:
+  * defaults will rarely need to be overriden
+  * configuration YAML is mostly dedicated to defining seeds, exclusion patterns, and other infrequently changing configurations
+  * runtime args for this app, `--sitemap-from-date`, change frequently and are therefore better exposed in this way vs defaults or YAML values    
+
+### How to provide the configuration YAML
+
+For local testing, it's advised to put the configuration YAML in the `output/`, e.g. `output/my-test-config.yaml`.  The host machine `output` directory is mounted to `/crawls` in the container, allowing you to kick off the crawl with something like:
+
+```shell
+--config-yaml-file="/crawls/my-test-config.yaml"
+```
+
+Or, see the local harvest test in the Makefile that is utilizing a test fixture:
+```shell
+--config-yaml-file="/browsertrix-harvester/tests/fixtures/lib-website-homepage.yaml"
+```
+                                                
+For deployed instances of this harvester -- e.g. invoked by the TIMDEX pipeline -- it's preferred to store the config YAML in S3 and pass that URI, e.g.:
+```shell
+--config-yaml-file="s3://timdex-extract-dev-222053980223/browsertrix-harvester-crawl-configs/library-wordpress.yaml"
+```
+
+## Convenience Make Commands
+
+### Local Test Crawl
+
+```shell
+make test-harvest-local
+```
+  * Performs a crawl using the container mounted config YAML `/browsertrix-harvest/tests/fixtures/lib-website-homepage.yaml`
+  * Metadata is written to container directory `/crawls/collections/homepage/homepage.xml`, which is mounted and available in the local `output/` folder 
+
+## Troubleshooting
+
+### Cannot read/write from S3 for a LOCAL docker container harvest
+
+If you are seeing errors like,
+
+```text
+botocore.exceptions.NoCredentialsError: Unable to locate credentials
+```
+
+it's likely that:
+1. either the config YAML or output files are attempting to read/write from S3 
+2. the container does not have AWS credentials to work with
+
+The Pipfile command `harvest-dockerized` mounts your host machine's `~/.aws` folder into the container to provide AWS credentials.  Copy/pasting credentials into the calling terminal is not sufficient.  Either `aws configure sso` or manually setting `~/.aws/credentials` file is required.

--- a/harvester/cli.py
+++ b/harvester/cli.py
@@ -105,7 +105,7 @@ def harvest(
 
     # upload WACZ if output file destination provided
     if wacz_output_file:
-        logger.info("writing WACZ archive to: %s", wacz_output_file)
+        logger.info("Writing WACZ archive to: %s", wacz_output_file)
         with smart_open.open(wacz_output_file, "wb") as wacz_out, smart_open.open(
             crawler.wacz_filepath, "rb"
         ) as wacz_in:

--- a/harvester/cli.py
+++ b/harvester/cli.py
@@ -92,7 +92,7 @@ def harvest(
     btrix_args_json: str,
 ) -> None:
     """Perform a web crawl and parse structured data."""
-    logger.info("preparing for harvest name: '%s'", crawl_name)
+    logger.info("Preparing for harvest name: '%s'", crawl_name)
     crawler = Crawler(
         crawl_name,
         config_yaml_file,
@@ -101,7 +101,7 @@ def harvest(
         btrix_args_json=btrix_args_json,
     )
     crawler.crawl()
-    logger.info("crawl complete, WACZ archive located at: %s", crawler.wacz_filepath)
+    logger.info("Crawl complete, WACZ archive located at: %s", crawler.wacz_filepath)
 
     # upload WACZ if output file destination provided
     if wacz_output_file is not None:

--- a/harvester/cli.py
+++ b/harvester/cli.py
@@ -3,7 +3,7 @@
 
 import logging
 import os
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from time import perf_counter
 
 import click
@@ -39,17 +39,18 @@ def shell(ctx: click.Context) -> None:
 
 @main.command()
 @click.option(
-    "--crawl-name",
-    required=True,
-    type=str,
-    help="Name of crawl",
-)
-@click.option(
     "--config-yaml-file",
     required=True,
     type=str,
     help="Filepath of browsertrix config YAML. Can be a local filepath or an S3 "
     "URI, e.g. s3://bucketname/crawl-config.yaml",
+)
+@click.option(
+    "--crawl-name",
+    required=False,
+    type=str,
+    default=f"crawl-{datetime.now(tz=UTC).strftime('%Y-%m-%d-%H%M%S')}",
+    help="Optional override for crawl name. [Default 'crawl-<TIMESTAMP>']",
 )
 @click.option(
     "--sitemap-from-date",

--- a/harvester/cli.py
+++ b/harvester/cli.py
@@ -104,7 +104,7 @@ def harvest(
     logger.info("Crawl complete, WACZ archive located at: %s", crawler.wacz_filepath)
 
     # upload WACZ if output file destination provided
-    if wacz_output_file is not None:
+    if wacz_output_file:
         logger.info("writing WACZ archive to: %s", wacz_output_file)
         with smart_open.open(wacz_output_file, "wb") as wacz_out, smart_open.open(
             crawler.wacz_filepath, "rb"

--- a/harvester/cli.py
+++ b/harvester/cli.py
@@ -3,11 +3,14 @@
 
 import logging
 import os
+from datetime import timedelta
 from time import perf_counter
 
 import click
+import smart_open  # type: ignore[import]
 
 from harvester.config import configure_logger, configure_sentry
+from harvester.crawl import Crawler
 
 logger = logging.getLogger(__name__)
 
@@ -32,3 +35,85 @@ def shell(ctx: click.Context) -> None:
     """Run a bash shell inside the docker container."""
     # ruff: noqa: S605, S607
     os.system("bash")
+
+
+@main.command()
+@click.option(
+    "--crawl-name",
+    required=True,
+    type=str,
+    help="Name of crawl",
+)
+@click.option(
+    "--config-yaml-file",
+    required=True,
+    type=str,
+    help="Filepath of browsertrix config YAML. Can be a local filepath or an S3 "
+    "URI, e.g. s3://bucketname/crawl-config.yaml",
+)
+@click.option(
+    "--sitemap-from-date",
+    required=False,
+    default=None,
+    type=str,
+    help="YYYY-MM-DD string to filter websites modified after this date in sitemaps",
+)
+@click.option(
+    "--wacz-output-file",
+    required=False,
+    help="Filepath to write WACZ archive file to. Can be a local filepath or an S3 URI, "
+    "e.g. s3://bucketname/filename.xml.",
+)
+@click.option(
+    "--num-workers",
+    default=2,
+    required=False,
+    type=int,
+    help="Number of parallel thread workers for crawler. [Default 2]",
+)
+@click.option(
+    "--btrix-args-json",
+    default=None,
+    required=False,
+    type=str,
+    help="JSON formatted string of additional args to pass to browsertrix-crawler, "
+    "https://github.com/webrecorder/browsertrix-crawler#crawling-configuration"
+    "-options",
+)
+@click.pass_context
+def harvest(
+    ctx: click.Context,
+    crawl_name: str,
+    config_yaml_file: str,
+    sitemap_from_date: str,
+    wacz_output_file: str,
+    num_workers: int,
+    btrix_args_json: str,
+) -> None:
+    """Perform a web crawl and parse structured data."""
+    logger.info("preparing for harvest name: '%s'", crawl_name)
+    crawler = Crawler(
+        crawl_name,
+        config_yaml_file,
+        sitemap_from_date=sitemap_from_date,
+        num_workers=num_workers,
+        btrix_args_json=btrix_args_json,
+    )
+    crawler.crawl()
+    logger.info("crawl complete, WACZ archive located at: %s", crawler.wacz_filepath)
+
+    # upload WACZ if output file destination provided
+    if wacz_output_file is not None:
+        logger.info("writing WACZ archive to: %s", wacz_output_file)
+        with smart_open.open(wacz_output_file, "wb") as wacz_out, smart_open.open(
+            crawler.wacz_filepath, "rb"
+        ) as wacz_in:
+            wacz_out.write(wacz_in.read())
+
+    elapsed_time = perf_counter() - ctx.obj["START_TIME"]
+    logger.info(
+        "Total time to complete harvest: %s",
+        str(
+            timedelta(seconds=elapsed_time),
+        ),
+    )

--- a/harvester/crawl.py
+++ b/harvester/crawl.py
@@ -1,0 +1,176 @@
+"""harvester.crawl"""
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+
+import smart_open  # type: ignore[import]
+
+from harvester.exceptions import ConfigYamlError
+from harvester.utils import require_container
+
+logger = logging.getLogger(__name__)
+
+
+class Crawler:
+    """Class that manages browsertrix crawls."""
+
+    DOCKER_CONTAINER_CONFIG_YAML_FILEPATH = "/browsertrix-harvester/crawl-config.yaml"
+
+    # ruff: noqa: FBT001, FBT002
+    def __init__(
+        self,
+        crawl_name: str,
+        config_yaml_filepath: str,
+        sitemap_from_date: str | None = None,
+        num_workers: int = 4,
+        btrix_args_json: str | None = None,
+    ) -> None:
+        self.crawl_name = crawl_name
+        self.config_yaml_filepath = config_yaml_filepath
+        self.sitemap_from_date = sitemap_from_date
+        self.num_workers = num_workers
+        self.btrix_args_json = btrix_args_json
+
+    @property
+    def crawl_output_dir(self) -> str:
+        return f"/crawls/collections/{self.crawl_name}"
+
+    @property
+    def wacz_filepath(self) -> str:
+        """Location of WACZ archive after crawl is completed."""
+        return f"{self.crawl_output_dir}/{self.crawl_name}.wacz"
+
+    @require_container
+    def crawl(self) -> tuple[int, list[str], list[str]]:
+        """Perform a browsertrix crawl.
+
+        This method is decorated with @required_container that will prevent it from
+        running if not inside a Docker container with the alias executable "crawl" that
+        is a symlink to the Browsertrix node application.
+
+        The crawl itself is invoked via a subprocess OS command that runs and waits for
+        the crawl to complete.
+        """
+        # copy config yaml to known, local file location
+        self._copy_config_yaml_local()
+
+        # remove pre-existing crawl
+        self._remove_previous_crawl()
+
+        # build subprocess command
+        cmd = self._build_subprocess_command()
+
+        stdout, stderr = [], []
+        # ruff: noqa: S603
+        with subprocess.Popen(
+            cmd,
+            cwd="/crawls",
+            env=self._get_subprocess_env_vars(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        ) as process:
+            if process.stdout is not None:  # pragma: no cover
+                for line in process.stdout:
+                    # ruff: noqa: PLW2901
+                    line = line.strip()
+                    if line is not None and line != "":
+                        logger.debug(line)
+                        stdout.append(line)
+            if process.stderr is not None:  # pragma: no cover
+                for line in process.stderr:
+                    # ruff: noqa: PLW2901
+                    line = line.strip()
+                    if line is not None and line != "":
+                        logger.debug(line)
+                        stderr.append(line)
+            return_code = process.wait()
+        return return_code, stdout, stderr
+
+    def _copy_config_yaml_local(self) -> None:
+        """Download and/or copy config YAML to expected location"""
+        logger.info(
+            "creating docker container copy of config YAML from: %s",
+            self.config_yaml_filepath,
+        )
+        try:
+            with smart_open.open(
+                self.config_yaml_filepath, "rb"
+            ) as f_in, smart_open.open(
+                self.DOCKER_CONTAINER_CONFIG_YAML_FILEPATH, "wb"
+            ) as f_out:
+                f_out.write(f_in.read())
+        except Exception as e:
+            logger.exception(
+                "could not open file locally or from S3: %s", self.config_yaml_filepath
+            )
+            raise ConfigYamlError from e
+
+    def _remove_previous_crawl(self) -> None:
+        """Remove previous crawl if exists.
+
+        Browsertrix will APPEND to previous crawls -- WARC files, indexed data, etc. -- if
+        the crawl directory already exists.  While the WACZ file will overwrite, this can
+        still introduce some unneeded complexity for a container that really should only
+        ever have one crawl per invocation.
+        """
+        if os.path.exists(self.crawl_output_dir):
+            logger.warning("removing pre-existing crawl at: %s", self.crawl_output_dir)
+            shutil.rmtree(self.crawl_output_dir)
+
+    def _build_subprocess_command(self) -> list:
+        """Build subprocess command that will execute browsertrix-crawler with args.
+
+        Build dictionary of key/value pairs from defaults defined here, common arguments
+        broken out as explicit CLI arguments, and any additional arguments passed as a
+        JSON string via CLI command that browsertrix accepts.  They are applied and
+        overridden in that order, then serialized as a flat list for OS command.
+        """
+        # build base command
+        cmd = [
+            "crawl",
+            "--useSitemap",
+        ]
+
+        # default args
+        btrix_args = {
+            "--collection": self.crawl_name,
+            "--config": self.DOCKER_CONTAINER_CONFIG_YAML_FILEPATH,
+            "--logging": "stats",
+        }
+
+        # apply common arguments as standalone CLI arguments
+        if self.num_workers is not None:
+            btrix_args["--workers"] = str(self.num_workers)
+        if self.sitemap_from_date is not None:
+            btrix_args["--sitemapFromDate"] = self.sitemap_from_date
+
+        # lastly, if JSON string of btrix args provided, parse and apply
+        if self.btrix_args_json is not None:
+            btrix_additional_args = json.loads(self.btrix_args_json)
+            for arg_name, arg_value in btrix_additional_args.items():
+                btrix_args[arg_name] = str(arg_value)
+
+        # flatten to list and extend base command
+        btrix_args_list = [item for sublist in btrix_args.items() for item in sublist]
+        cmd.extend(btrix_args_list)
+
+        logger.info(cmd)
+
+        return cmd
+
+    @staticmethod
+    def _get_subprocess_env_vars() -> dict:
+        """Prepare env vars for subprocess that calls browsertrix-crawler
+
+        Browsertrix is a node application that runs in this container, and relies on
+        some global python libraries.  Because this CLI app, browsertrix-harvester, runs
+        in a pipenv virtual environment, it's required to UNSET a couple of env vars when
+        calling the os command to crawl.
+        """
+        env_vars = dict(os.environ)
+        env_vars.pop("VIRTUAL_ENV", None)
+        return env_vars

--- a/harvester/crawl.py
+++ b/harvester/crawl.py
@@ -93,7 +93,7 @@ class Crawler:
     def _copy_config_yaml_local(self) -> None:
         """Download and/or copy config YAML to expected location"""
         logger.info(
-            "creating docker container copy of config YAML from: %s",
+            "Creating docker container copy of config YAML from: %s",
             self.config_yaml_filepath,
         )
         try:
@@ -105,7 +105,7 @@ class Crawler:
                 f_out.write(f_in.read())
         except Exception as e:
             logger.exception(
-                "could not open file locally or from S3: %s", self.config_yaml_filepath
+                "Could not open file locally or from S3: %s", self.config_yaml_filepath
             )
             raise ConfigYamlError from e
 
@@ -118,7 +118,7 @@ class Crawler:
         ever have one crawl per invocation.
         """
         if os.path.exists(self.crawl_output_dir):
-            logger.warning("removing pre-existing crawl at: %s", self.crawl_output_dir)
+            logger.warning("Removing pre-existing crawl at: %s", self.crawl_output_dir)
             shutil.rmtree(self.crawl_output_dir)
 
     def _build_subprocess_command(self) -> list:

--- a/harvester/crawl.py
+++ b/harvester/crawl.py
@@ -73,18 +73,18 @@ class Crawler:
             stderr=subprocess.PIPE,
             text=True,
         ) as process:
-            if process.stdout is not None:  # pragma: no cover
+            if process.stdout:  # pragma: no cover
                 for line in process.stdout:
                     # ruff: noqa: PLW2901
                     line = line.strip()
-                    if line is not None and line != "":
+                    if line and line != "":
                         logger.debug(line)
                         stdout.append(line)
-            if process.stderr is not None:  # pragma: no cover
+            if process.stderr:  # pragma: no cover
                 for line in process.stderr:
                     # ruff: noqa: PLW2901
                     line = line.strip()
-                    if line is not None and line != "":
+                    if line and line != "":
                         logger.debug(line)
                         stderr.append(line)
             return_code = process.wait()

--- a/harvester/exceptions.py
+++ b/harvester/exceptions.py
@@ -1,0 +1,14 @@
+"""browsertrix_harvest.exceptions."""
+# ruff: noqa: N818
+
+
+class RequiresContainerContextError(Exception):
+    pass
+
+
+class WaczFileDoesNotExist(Exception):
+    pass
+
+
+class ConfigYamlError(Exception):
+    pass

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -1,0 +1,24 @@
+"""harvester.utils"""
+# ruff: noqa: ANN401
+
+import os
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+from harvester.exceptions import RequiresContainerContextError
+
+ReturnType = TypeVar("ReturnType")
+
+
+def require_container(func: Callable[..., ReturnType]) -> Callable[..., ReturnType]:
+    """Decorator for functions/methods that must be run inside the Docker container."""
+
+    def wrapper(*args: Any, **kwargs: Any) -> ReturnType:
+        if (
+            not os.path.exists("/.dockerenv")
+            and os.getenv("AWS_EXECUTION_ENV", None) is None
+        ):
+            raise RequiresContainerContextError
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -11,7 +11,13 @@ ReturnType = TypeVar("ReturnType")
 
 
 def require_container(func: Callable[..., ReturnType]) -> Callable[..., ReturnType]:
-    """Decorator for functions/methods that must be run inside the Docker container."""
+    """Decorator for functions/methods that must be run inside the Docker container.
+
+    This checks to see if application is running in a container by looking for either a
+    /.dockerenv file exists (created automatically by Docker and indicates locally running
+    docker container) or the environment variable AWS_EXECUTION_ENV is set (set
+    automatically by, and indicates, a running Fargate ECS task).
+    """
 
     def wrapper(*args: Any, **kwargs: Any) -> ReturnType:
         if (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,10 @@
+import os
+from unittest.mock import Mock, mock_open, patch
+
 import pytest
 from click.testing import CliRunner
+
+from harvester.crawl import Crawler
 
 
 @pytest.fixture(autouse=True)
@@ -12,3 +17,42 @@ def _test_env(monkeypatch):
 @pytest.fixture
 def runner():
     return CliRunner()
+
+
+@pytest.fixture
+def fake_config_yaml_content():
+    return "fake config YAML data"
+
+
+@pytest.fixture
+def mock_config_yaml_open(fake_config_yaml_content, request):
+    should_raise = request.node.get_closest_marker(name="raise_smart_open_exception")
+    if should_raise:
+        mock_s_open = Mock(side_effect=Exception("Mocked exception"))
+    else:
+        mock_s_open = mock_open(read_data=fake_config_yaml_content)
+    with patch("smart_open.open", mock_s_open):
+        yield mock_s_open
+
+
+@pytest.fixture
+def create_mocked_crawler(mock_config_yaml_open):
+    def crawler_factory() -> Crawler:
+        return Crawler(
+            crawl_name="test",
+            config_yaml_filepath="path/to/fake_config.yaml",
+        )
+
+    return crawler_factory
+
+
+@pytest.fixture
+def _mock_inside_container():
+    def mock_exists(path):
+        if path == "/.dockerenv":
+            return True
+        return original_exists(path)
+
+    original_exists = os.path.exists
+    with patch("os.path.exists", side_effect=mock_exists):
+        yield

--- a/tests/fixtures/lib-website-homepage.yaml
+++ b/tests/fixtures/lib-website-homepage.yaml
@@ -1,0 +1,19 @@
+generateCDX: true
+generateWACZ: true
+text: true
+# prevent PAGES from getting crawled; scoping
+exclude:
+  - ".*lib.mit.edu/search/.*"
+  - ".*mit.primo.exlibrisgroup.com/.*"
+# prevent RESOURCES / ASSETS from getting retrieved; URL requests
+blockRules:
+  - ".*googlevideo.com.*"
+  - ".*cdn.pw-60-mitlib-wp-network.pantheonsite.io/media/.*"
+  - "\\.(jpg|png)$"
+depth: 1
+maxPageLimit: 20
+timeout: 10
+scopeType: "domain"
+seeds:
+  - url: https://pw-60-mitlib-wp-network.pantheonsite.io/sitemap.xml
+    sitemap: https://pw-60-mitlib-wp-network.pantheonsite.io/sitemap.xml

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,7 +43,7 @@ def test_cli_harvest_required_options_bad_yaml(caplog, runner):
             "/files/does/not/exist.yaml",
         ],
     )
-    assert "preparing for harvest name: 'homepage'" in caplog.text
+    assert "Preparing for harvest name: 'homepage'" in caplog.text
     assert (
         "could not open file locally or from S3: /files/does/not/exist.yaml"
         in caplog.text
@@ -70,7 +70,7 @@ def test_cli_harvest_required_options_good_yaml(caplog, runner):
         )
 
         assert (
-            "crawl complete, WACZ archive located at: "
+            "Crawl complete, WACZ archive located at: "
             "/crawls/collections/homepage/homepage.wacz" in caplog.text
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,13 +25,13 @@ def test_cli_docker_shell(caplog, runner):
         assert result.exit_code == 0
 
 
-def test_cli_harvest_missing_options(caplog, runner):
+def test_cli_harvest_missing_options_raises_error(caplog, runner):
     result = runner.invoke(main, ["--verbose", "harvest", "--crawl-name", "homepage"])
     assert "Error: Missing option '--config-yaml-file'" in result.output
 
 
 @pytest.mark.usefixtures("_mock_inside_container")
-def test_cli_harvest_required_options_bad_yaml(caplog, runner):
+def test_cli_harvest_required_options_bad_yaml_raises_error(caplog, runner):
     runner.invoke(
         main,
         [
@@ -45,7 +45,7 @@ def test_cli_harvest_required_options_bad_yaml(caplog, runner):
     )
     assert "Preparing for harvest name: 'homepage'" in caplog.text
     assert (
-        "could not open file locally or from S3: /files/does/not/exist.yaml"
+        "Could not open file locally or from S3: /files/does/not/exist.yaml"
         in caplog.text
     )
 
@@ -93,6 +93,6 @@ def test_cli_harvest_write_wacz(caplog, runner):
                 "/tmp/homepage.wacz",
             ],
         )
-        assert "writing WACZ archive to: /tmp/homepage.wacz" in caplog.text
+        assert "Writing WACZ archive to: /tmp/homepage.wacz" in caplog.text
         assert call("/tmp/homepage.wacz", "wb")
         assert call("/crawls/collections/homepage/homepage.wacz", "rb")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,9 +26,6 @@ def test_cli_docker_shell(caplog, runner):
 
 
 def test_cli_harvest_missing_options(caplog, runner):
-    result = runner.invoke(main, ["--verbose", "harvest"])
-    assert "Error: Missing option '--crawl-name'." in result.output
-
     result = runner.invoke(main, ["--verbose", "harvest", "--crawl-name", "homepage"])
     assert "Error: Missing option '--config-yaml-file'" in result.output
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,10 @@
 """tests.test_parser"""
 # ruff: noqa: S108
 
-from unittest.mock import patch
+from unittest.mock import call, mock_open, patch
+
+import pytest
+import smart_open
 
 from harvester.cli import main
 
@@ -20,3 +23,79 @@ def test_cli_docker_shell(caplog, runner):
         result = runner.invoke(main, ["--verbose", "shell"])
         mock_system.assert_called_with("bash")
         assert result.exit_code == 0
+
+
+def test_cli_harvest_missing_options(caplog, runner):
+    result = runner.invoke(main, ["--verbose", "harvest"])
+    assert "Error: Missing option '--crawl-name'." in result.output
+
+    result = runner.invoke(main, ["--verbose", "harvest", "--crawl-name", "homepage"])
+    assert "Error: Missing option '--config-yaml-file'" in result.output
+
+
+@pytest.mark.usefixtures("_mock_inside_container")
+def test_cli_harvest_required_options_bad_yaml(caplog, runner):
+    runner.invoke(
+        main,
+        [
+            "--verbose",
+            "harvest",
+            "--crawl-name",
+            "homepage",
+            "--config-yaml-file",
+            "/files/does/not/exist.yaml",
+        ],
+    )
+    assert "preparing for harvest name: 'homepage'" in caplog.text
+    assert (
+        "could not open file locally or from S3: /files/does/not/exist.yaml"
+        in caplog.text
+    )
+
+
+@pytest.mark.usefixtures("_mock_inside_container")
+def test_cli_harvest_required_options_good_yaml(caplog, runner):
+    with patch("harvester.crawl.Crawler.crawl"), patch.object(
+        smart_open, "open", mock_open()
+    ):
+        runner.invoke(
+            main,
+            [
+                "--verbose",
+                "harvest",
+                "--crawl-name",
+                "homepage",
+                "--config-yaml-file",
+                "tests/fixtures/lib-website-homepage.yaml",
+                "--wacz-output-file",
+                "/tmp/homepage.wacz",
+            ],
+        )
+
+        assert (
+            "crawl complete, WACZ archive located at: "
+            "/crawls/collections/homepage/homepage.wacz" in caplog.text
+        )
+
+
+@pytest.mark.usefixtures("_mock_inside_container")
+def test_cli_harvest_write_wacz(caplog, runner):
+    with patch("harvester.crawl.Crawler.crawl"), patch.object(
+        smart_open, "open", mock_open()
+    ):
+        runner.invoke(
+            main,
+            [
+                "--verbose",
+                "harvest",
+                "--crawl-name",
+                "homepage",
+                "--config-yaml-file",
+                "tests/fixtures/lib-website-homepage.yaml",
+                "--wacz-output-file",
+                "/tmp/homepage.wacz",
+            ],
+        )
+        assert "writing WACZ archive to: /tmp/homepage.wacz" in caplog.text
+        assert call("/tmp/homepage.wacz", "wb")
+        assert call("/crawls/collections/homepage/homepage.wacz", "rb")

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,131 @@
+"""tests.test_crawler"""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from harvester.exceptions import (
+    ConfigYamlError,
+    RequiresContainerContextError,
+)
+
+
+def test_crawler_config_yaml_copy_success(
+    create_mocked_crawler, mock_config_yaml_open, fake_config_yaml_content
+):
+    crawler = create_mocked_crawler()
+    crawler._copy_config_yaml_local()
+
+    # assert input file was opened for read and output file was opened for write
+    mock_config_yaml_open.assert_any_call(crawler.config_yaml_filepath, "rb")
+    mock_config_yaml_open.assert_any_call(
+        crawler.DOCKER_CONTAINER_CONFIG_YAML_FILEPATH, "wb"
+    )
+
+    # assert data written is expected data from config YAML
+    handle = mock_config_yaml_open()
+    handle.write.assert_called_once_with(fake_config_yaml_content)
+
+
+@pytest.mark.raise_smart_open_exception
+def test_crawler_config_yaml_copy_fail(create_mocked_crawler):
+    mock_crawler = create_mocked_crawler()
+    # assert ConfigYamlError thrown
+    with pytest.raises(ConfigYamlError):
+        mock_crawler._copy_config_yaml_local()
+
+
+def test_crawler_properties(create_mocked_crawler):
+    crawler = create_mocked_crawler()
+    assert (
+        crawler.wacz_filepath == f"{crawler.crawl_output_dir}/{crawler.crawl_name}.wacz"
+    )
+
+
+def test_crawler_env_var_manipulation(create_mocked_crawler):
+    assert os.getenv("VIRTUAL_ENV", None) is not None
+    crawler = create_mocked_crawler()
+    # ruff: noqa: SLF001
+    env_vars = crawler._get_subprocess_env_vars()
+    assert "VIRTUAL_ENV" not in env_vars
+
+
+def test_crawl_docker_context_decorator(create_mocked_crawler):
+    with pytest.raises(RequiresContainerContextError):
+        create_mocked_crawler().crawl()
+
+
+def test_crawl_remove_previous_crawl(create_mocked_crawler):
+    crawler = create_mocked_crawler()
+
+    # assert removal
+    with patch("os.path.exists", return_value=True), patch(
+        "shutil.rmtree"
+    ) as mock_rmtree:
+        crawler._remove_previous_crawl()
+        mock_rmtree.assert_called_once_with(crawler.crawl_output_dir)
+
+    # assert skips removal
+    with patch("os.path.exists", return_value=False), patch(
+        "shutil.rmtree"
+    ) as mock_rmtree:
+        crawler._remove_previous_crawl()
+        mock_rmtree.assert_not_called()
+
+
+def test_crawler_build_command(create_mocked_crawler):
+    crawler = create_mocked_crawler()
+
+    base_args = {
+        # fmt: off
+        "crawl",
+        "--collection", crawler.crawl_name,
+        "--config", crawler.DOCKER_CONTAINER_CONFIG_YAML_FILEPATH,
+        "--useSitemap",
+        "--logging", "stats",
+        "--workers", str(crawler.num_workers),
+        # fmt: on
+    }
+
+    # assert without sitemap_from_date
+    crawler.sitemap_from_date = None
+    command = crawler._build_subprocess_command()
+    assert set(command) == base_args
+
+    # assert when sitemap_from_date is included
+    from_date = "1979-01-01"
+    crawler.sitemap_from_date = from_date
+    command = crawler._build_subprocess_command()
+    assert set(command) == base_args.union({"--sitemapFromDate", from_date})
+
+    # assert inclusion of misc btrix args JSON
+    crawler = create_mocked_crawler()
+    crawler.btrix_args_json = json.dumps({"--miscArg1": "value1", "--miscArg2": "value2"})
+    command = crawler._build_subprocess_command()
+    assert set(command) == base_args.union(
+        {"--miscArg1", "value1", "--miscArg2", "value2"}
+    )
+
+
+@pytest.mark.usefixtures("_mock_inside_container")
+def test_crawl_success(create_mocked_crawler):
+    crawler = create_mocked_crawler()
+
+    stdouts = ["stdout1", "", "stdout2"]
+    stderrs = ["stderr1", "stderr2", ""]
+
+    # create a mock subprocess process with
+    mock_process = MagicMock()
+    mock_process.__enter__.return_value = mock_process
+    mock_process.__exit__.return_value = None
+    mock_process.stdout = iter(stdouts)
+    mock_process.stderr = iter(stderrs)
+    mock_process.wait.return_value = 0
+
+    with patch("subprocess.Popen", return_value=mock_process):
+        return_code, stdout, stderr = crawler.crawl()
+        assert return_code == 0
+        assert stdout == [_ for _ in stdouts if _ != ""]  # empty strings are skipped
+        assert stderr == [_ for _ in stderrs if _ != ""]  # empty strings are skipped


### PR DESCRIPTION
### What does this PR do?

This PR adds the browsertrix web crawling functionality to the harvester app.  

This begins to build out the CLI command `harvest`.  At this point, all it can do is perform a web crawl, and optionally write a WACZ file to a local or remote location, but no metadata records are parsed.

As outlined in the README, a web crawl will _only_ run in a containerized context.

### How can a reviewer manually see the effects of these changes?

The easiest way to confirm a web crawl can be performed is to use a convenience Makefile command is configured to run a small web crawl:

```shell
# rebuild the image with new code
make dist-local

# perform local web crawl that will write assets to ./output/crawls
make test-harvest-local
```

The crawl configuration used (`tests/fixtures/lib-website-homepage.yaml`) is configured to use a single sitemap XML file, which (as of this writing) is returning 139 sites.  But there is a max page limit set to 20 pages, and _then_ an additional runtime override using JSON arguments to limit to 15, thereby testing both configuration approaches; final result should be 15 crawled websites.

The crawl should take roughly 1-2 minutes, and will output a WACZ file to `output/crawls/collections/homepage/homepage.wacz`.

To further dig into the results of this crawl, you can unzip this file and observe the contents:
```shell
cd output/crawls/collections/homepage
mkdir wacz_content
cd wacz_content
unzip ../homepage.wacz
```

And the file structure should look like this:
```text
.
├── archive
│   ├── rec-20231003150448167240-c24c9596f4b2.warc.gz
│   ├── rec-20231003150448496200-c24c9596f4b2.warc.gz
│   ├── rec-20231003150450050541-c24c9596f4b2.warc.gz
│   ├── rec-20231003150450196576-c24c9596f4b2.warc.gz
│   ├── rec-20231003150450635219-c24c9596f4b2.warc.gz
│   ├── rec-20231003150450850474-c24c9596f4b2.warc.gz
│   ├── rec-20231003150451119787-c24c9596f4b2.warc.gz
│   ├── rec-20231003150451283860-c24c9596f4b2.warc.gz
│   ├── rec-20231003150451471183-c24c9596f4b2.warc.gz
│   └── rec-20231003150451641445-c24c9596f4b2.warc.gz
├── datapackage-digest.json
├── datapackage.json
├── indexes
│   ├── index.cdx.gz
│   └── index.idx
├── logs
│   └── crawl-20231003150430042.log
└── pages
    ├── extraPages.jsonl
    └── pages.jsonl
```

### Includes new or updated dependencies?

NO

### What are the relevant tickets?

https://mitlibraries.atlassian.net/browse/TIMX-247

### Developer

- [X] All new ENV is documented in README (or there is none)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
