### PR TITLE
TIMX 557 and misc updates

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "attrs": {
             "hashes": [
-                "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3",
-                "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"
+                "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11",
+                "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==25.3.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==25.4.0"
         },
         "beautifulsoup4": {
             "hashes": [
@@ -34,19 +34,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:281ddf688951773a98161ccb34c54c6376b2ecc7028ab99d77483df5990b448c",
-                "sha256:84ade2a253e5445902d2cb2064f48aedf9ba83d6f863244266c2e36c2f190cec"
+                "sha256:5b145752d20f29908e3cb8c823bee31c77e6bcf18787e570f36bbc545cc779ed",
+                "sha256:e8d794dc1f01729d93dc188c90cf63cd0d32df8818a82ac46e641f6ffcea615e"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.40.44"
+            "version": "==1.40.45"
         },
         "botocore": {
             "hashes": [
-                "sha256:6fa7274cdb69be7c7b3ce6ff46a7c3e35e270f259dd77ee3f8ad8c584352262b",
-                "sha256:8f6f96ef053dcdfe79c14dfee303c0d381608c111696862fafc6e38402ccf8fe"
+                "sha256:9abf473d8372ade8442c0d4634a9decb89c854d7862ffd5500574eb63ab8f240",
+                "sha256:cf8b743527a2a7e108702d24d2f617e93c6dc7ae5eb09aadbe866f15481059df"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.40.44"
+            "version": "==1.40.45"
         },
         "bs4": {
             "hashes": [
@@ -58,11 +58,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407",
-                "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5"
+                "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de",
+                "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2025.8.3"
+            "version": "==2025.10.5"
         },
         "charset-normalizer": {
             "hashes": [
@@ -576,12 +576,12 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:8c185854d111f47f329ab6bc35993f28f7a6b7114db64aa426b326998cfa14e9",
-                "sha256:ba655ca5e57b41569b18e2a5552cb3375209760a5d332cdd87c6c3f28f729602"
+                "sha256:b9c4672fb2cafabcc28586ab8fd0ceeff9b2352afcf2b936e13d5ba06d141b9f",
+                "sha256:d5f6ae0f27ea73e7b09c70ad7d42242326eb44765e87a15d8c5aab96b80013e6"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.6'",
-            "version": "==2.39.0"
+            "version": "==2.40.0"
         },
         "six": {
             "hashes": [
@@ -829,11 +829,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407",
-                "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5"
+                "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de",
+                "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2025.8.3"
+            "version": "==2025.10.5"
         },
         "cffi": {
             "hashes": [
@@ -1870,11 +1870,11 @@
         },
         "pydantic": {
             "hashes": [
-                "sha256:6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2",
-                "sha256:c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2"
+                "sha256:802a655709d49bd004c31e865ef37da30b540786a46bfce02333e0e24b5fe29a",
+                "sha256:dc280f0982fbda6c38fada4e476dc0a4f3aeaf9c6ad4c28df68a666ec3c61423"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.11.9"
+            "version": "==2.11.10"
         },
         "pydantic-core": {
             "hashes": [

--- a/harvester/cli.py
+++ b/harvester/cli.py
@@ -89,7 +89,7 @@ def parse_url_content(wacz_input_file: str, url: str) -> None:
 )
 @click.option(
     "--metadata-output-file",
-    required=False,
+    required=True,
     help="Filepath to write metadata records to. Can be a local filepath or an S3 URI, "
     "e.g. s3://bucketname/filename.jsonl.  Supported file type extensions: "
     "[jsonl, xml,tsv,csv].",
@@ -99,12 +99,18 @@ def parse_url_content(wacz_input_file: str, url: str) -> None:
     is_flag=True,
     help="Set to include parsed fulltext from website in generated structured metadata.",
 )
+@click.option(
+    "--extract-fulltext-keywords",
+    is_flag=True,
+    help="Set to use YAKE to extract keywords from fulltext.",
+)
 @click.pass_context
 def generate_metadata_records(
     ctx: click.Context,
     wacz_input_file: str,
     metadata_output_file: str,
     include_fulltext: bool,
+    extract_fulltext_keywords: bool,
 ) -> None:
     """Generate metadata records from a WACZ file.
 
@@ -115,9 +121,11 @@ def generate_metadata_records(
     """
     logger.info("Parsing WACZ archive file")
     parser = CrawlMetadataParser(wacz_input_file)
-    parser.generate_metadata(include_fulltext=include_fulltext).write(
-        metadata_output_file
+    crawl_metadata_records = parser.generate_metadata(
+        include_fulltext=include_fulltext,
+        extract_fulltext_keywords=extract_fulltext_keywords,
     )
+    crawl_metadata_records.write(metadata_output_file)
     logger.info("Metadata records successfully written")
     logger.info(
         "Total elapsed: %s",
@@ -168,6 +176,11 @@ def generate_metadata_records(
     help="Set to include parsed fulltext from website in generated structured metadata.",
 )
 @click.option(
+    "--extract-fulltext-keywords",
+    is_flag=True,
+    help="Set to use YAKE to extract keywords from fulltext.",
+)
+@click.option(
     "--num-workers",
     default=2,
     required=False,
@@ -192,6 +205,7 @@ def harvest(
     wacz_output_file: str,
     metadata_output_file: str,
     include_fulltext: bool,
+    extract_fulltext_keywords: bool,
     num_workers: int,
     btrix_args_json: str,
 ) -> None:
@@ -230,9 +244,11 @@ def harvest(
     if metadata_output_file:
         logger.info("Parsing WACZ archive file")
         parser = CrawlMetadataParser(crawler.wacz_filepath)
-        parser.generate_metadata(include_fulltext=include_fulltext).write(
-            metadata_output_file
+        crawl_metadata_records = parser.generate_metadata(
+            include_fulltext=include_fulltext,
+            extract_fulltext_keywords=extract_fulltext_keywords,
         )
+        crawl_metadata_records.write(metadata_output_file)
         logger.info("Metadata records successfully written")
 
     logger.info(

--- a/harvester/metadata.py
+++ b/harvester/metadata.py
@@ -81,7 +81,12 @@ class CrawlMetadataParser:
         self._websites_metadata: CrawlMetadataRecords | None = None
         self._keyword_extractor: KeywordExtractor | None = None
 
-    def generate_metadata(self, include_fulltext: bool = False) -> "CrawlMetadataRecords":
+    def generate_metadata(
+        self,
+        *,
+        include_fulltext: bool = False,
+        extract_fulltext_keywords: bool = False,
+    ) -> "CrawlMetadataRecords":
         """Generate dataframe of metadata records from websites crawled in WACZ file.
 
         This combines metadata from the crawl (e.g. URL, extracted fulltext), and
@@ -94,7 +99,6 @@ class CrawlMetadataParser:
             return self._websites_metadata
 
         with WACZClient(self.wacz_filepath) as wacz_client:
-            # bookkeeping
             all_metadata = []
             t0 = time.time()
             row_count = len(wacz_client.html_websites_df)
@@ -129,6 +133,7 @@ class CrawlMetadataParser:
                     self.parse_fulltext_fields(
                         row.text,  # type:ignore[arg-type]
                         include_fulltext=include_fulltext,
+                        extract_fulltext_keywords=extract_fulltext_keywords,
                     )
                 )
 
@@ -169,9 +174,7 @@ class CrawlMetadataParser:
 
     def _remove_fulltext_whitespace(self, fulltext: str) -> str:
         """Remove whitespace from provided fulltext."""
-        fulltext = fulltext.replace("\n", " ").replace("\r", " ").replace("\t", " ")
-        # ruff: noqa: RET504
-        return fulltext
+        return fulltext.replace("\n", " ").replace("\r", " ").replace("\t", " ")
 
     def _generate_fulltext_keywords(self, fulltext: str) -> str:
         """Parse keywords from fulltext, using YAKE keyword extractor.
@@ -185,27 +188,29 @@ class CrawlMetadataParser:
     def parse_fulltext_fields(
         self,
         raw_fulltext: str | None,
-        # ruff: noqa: FBT001, FBT002
-        include_fulltext: bool = False,
-        include_fulltext_keywords: bool = True,
+        *,
+        include_fulltext: bool = True,
+        extract_fulltext_keywords: bool = False,
     ) -> dict:
         """Parse fulltext fields for output metadata."""
-        if not raw_fulltext:
-            return {
-                "fulltext": None,
-                "fulltext_50_words": None,
-                "fulltext_keywords": None,
-            }
+        fields: dict[str, str | None] = {
+            "fulltext": None,
+            "fulltext_keywords": None,
+        }
+
+        # return early if no fulltext fields requested
+        if not (include_fulltext or extract_fulltext_keywords) or raw_fulltext is None:
+            return fields
 
         fulltext = self._remove_fulltext_whitespace(raw_fulltext)
-        return {
-            "fulltext": fulltext if include_fulltext else None,
-            "fulltext_keywords": (
-                self._generate_fulltext_keywords(fulltext)
-                if include_fulltext_keywords
-                else None
-            ),
-        }
+
+        if include_fulltext:
+            fields["fulltext"] = fulltext
+
+        if extract_fulltext_keywords:
+            fields["fulltext_keywords"] = self._generate_fulltext_keywords(fulltext)
+
+        return fields
 
     @property
     def keyword_extractor(self) -> KeywordExtractor:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -208,3 +208,24 @@ def test_cli_generate_metadata_records_jsonlines(caplog, runner):
     assert "Parsing WACZ archive file" in caplog.text
     assert mock_generate_metadata.called
     assert "Metadata records successfully written" in caplog.text
+
+
+def test_cli_generate_metadata_records_with_fulltext_flags(runner):
+    with patch(
+        "harvester.metadata.CrawlMetadataParser.generate_metadata",
+    ) as mock_generate_metadata:
+        runner.invoke(
+            main,
+            [
+                "generate-metadata-records",
+                "--wacz-input-file",
+                "tests/fixtures/homepage.wacz",
+                "--metadata-output-file",
+                "/tmp/records.xml",
+                "--include-fulltext",
+                "--extract-fulltext-keywords",
+            ],
+        )
+        mock_generate_metadata.assert_called_once_with(
+            include_fulltext=True, extract_fulltext_keywords=True
+        )

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -116,22 +116,15 @@ def test_crawler_build_command(create_mocked_crawler):
 def test_crawl_success(create_mocked_crawler):
     crawler = create_mocked_crawler()
 
-    stdouts = ["stdout1", "", "stdout2"]
-    stderrs = ["stderr1", "stderr2", ""]
-
     # create a mock subprocess process with
     mock_process = MagicMock()
     mock_process.__enter__.return_value = mock_process
     mock_process.__exit__.return_value = None
-    mock_process.stdout = iter(stdouts)
-    mock_process.stderr = iter(stderrs)
     mock_process.wait.return_value = 0
 
     with patch("subprocess.Popen", return_value=mock_process):
-        return_code, stdout, stderr = crawler.crawl()
+        return_code = crawler.crawl()
         assert return_code == 0
-        assert stdout == [_ for _ in stdouts if _ != ""]  # empty strings are skipped
-        assert stderr == [_ for _ in stderrs if _ != ""]  # empty strings are skipped
 
 
 @pytest.mark.usefixtures("_mock_inside_container")

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -100,6 +100,20 @@ def test_metadata_parser_remove_whitespace_fulltext(mocked_parser):
     )
 
 
+def test_metadata_parser_remove_duplicate_urls(mocked_parser):
+    df = pd.DataFrame(
+        {
+            "url": ["https://example.com", "https://example.com", "https://other.com"],
+            "cdx_offset": [100, 200, 150],
+        }
+    )
+    result = mocked_parser._remove_duplicate_urls(df)
+    assert len(result) == 2
+    assert (
+        result[result["url"] == "https://example.com"]["cdx_offset"].to_numpy()[0] == 200
+    )
+
+
 def test_metadata_parser_generate_keywords(mocked_parser):
     fulltext = "My favorite colors are: green, red, blue, and orange."
     with patch("yake.KeywordExtractor.extract_keywords") as mocked_keyword_extractor:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -106,3 +106,39 @@ def test_metadata_parser_generate_keywords(mocked_parser):
         mocked_keyword_extractor.return_value = [("green", "0.5"), ("red", "0.5")]
         keywords = mocked_parser._generate_fulltext_keywords(fulltext)
         assert keywords == "green,red"
+
+
+def test_metadata_parser_parse_fulltext_fields_include_fulltext(mocked_parser):
+    fields = mocked_parser.parse_fulltext_fields(
+        "Hello world!\nTest text.", include_fulltext=True, extract_fulltext_keywords=False
+    )
+    assert fields["fulltext"] == "Hello world! Test text."
+    assert fields["fulltext_keywords"] is None
+
+
+def test_metadata_parser_parse_fulltext_fields_extract_keywords(mocked_parser):
+    with patch("yake.KeywordExtractor.extract_keywords") as mock_extractor:
+        mock_extractor.return_value = [("hello", "0.5"), ("world", "0.5")]
+        fields = mocked_parser.parse_fulltext_fields(
+            "Hello world!", include_fulltext=False, extract_fulltext_keywords=True
+        )
+    assert fields["fulltext"] is None
+    assert fields["fulltext_keywords"] == "hello,world"
+
+
+def test_metadata_parser_parse_fulltext_fields_both_flags(mocked_parser):
+    with patch("yake.KeywordExtractor.extract_keywords") as mock_extractor:
+        mock_extractor.return_value = [("test", "0.5")]
+        fields = mocked_parser.parse_fulltext_fields(
+            "Test text", include_fulltext=True, extract_fulltext_keywords=True
+        )
+    assert fields["fulltext"] == "Test text"
+    assert fields["fulltext_keywords"] == "test"
+
+
+def test_metadata_parser_parse_fulltext_fields_no_flags(mocked_parser):
+    fields = mocked_parser.parse_fulltext_fields(
+        "Hello world!", include_fulltext=False, extract_fulltext_keywords=False
+    )
+    assert fields["fulltext"] is None
+    assert fields["fulltext_keywords"] is None


### PR DESCRIPTION
### Purpose and background context

This PR makes a few small updates to the `browsertrix-harvester` as we get into analyzing results and thinking about deploying it for TIMDEX.

Updates in this PR are broken down by commit and include:
- cleanup handling of including/excluding website fulltext in the output metadata records ([commit](https://github.com/MITLibraries/browsertrix-harvester/pull/44/commits/9e84442802fa9c6e62d8035c322256479027b480))
- surface crawl updates during non-verbose runs ([commit](https://github.com/MITLibraries/browsertrix-harvester/pull/44/commits/3fa543b5ff157083f2bf1c4ae81aaf5b19ed65e0))
- removing duplicate URLs from output metadata ([commit](https://github.com/MITLibraries/browsertrix-harvester/pull/44/commits/56b46f2d8629a3aa93e95e822fd573415bdc1b0a))

### How can a reviewer manually see the effects of these changes?

All changes from this PR can be seen in a small(ish) local run.

1- Build the container:

```shell
make dist-local
```

2- Create the folder `output/crawls` at the root of the repository.

3- Create the folder `output/crawls/config` and add the following file:

[mitlibwebsite.yaml](https://github.com/user-attachments/files/22730551/mitlibwebsite.yaml)

4- Run a crawl:

```shell
export CRAWL_NAME="mitlibwebsite-2025-10-06-full"
pipenv run harvester-dockerized harvest \
        --crawl-name="${CRAWL_NAME}" \
        --config-yaml-file="/crawls/configs/mitlibwebsite.yaml" \
        --metadata-output-file="/crawls/collections/${CRAWL_NAME}/${CRAWL_NAME}-extracted-records-to-index.jsonl" \
        --num-workers 16 \
        --btrix-args-json='{"--maxPageLimit":"200"}'
```

5- Note that during the crawl, logging is fairly minimal with the absence of `--verbose`, but some status updates roll through that look similar to:

```
2025-10-06 20:38:04,570 INFO harvester.crawl._log_crawl_count_status(): {'crawled': 86, 'total': 200, 'pending': 16, 'failed': 0, 'limit': {'max': 200, 'hit': True}}
2025-10-06 20:38:45,708 INFO harvester.crawl._log_crawl_count_status(): {'crawled': 177, 'total': 191, 'pending': 14, 'failed': 0, 'limit': {'max': 200, 'hit': True}}
```

6- Analyzing the metadata output file at `output/crawls/collections/mitlibwebsite-2025-10-06-full/mitlibwebsite-2025-10-06-full-extracted-records-to-index.jsonl`, note the following:
- the `url` field is unique across all records
- columns `fulltext` and `fulltext_keywords` are both `NULL`, because neither `--include-fulltext` or `--extract-fulltext-keywords` were passed

DuckDB can be a handy way to analyze the metadata JSONLines:

```shell
# start duckdb
duckdb
```

```sql
-- create a view from the JSONLines
create view records as select * from read_json('output/crawls/collections/mitlibwebsite-2025-10-06-full/mitlibwebsite-2025-10-06-full-extracted-records-to-index.jsonl');

-- confirm that URL is unique
select url, count(url) from records group by url order by count(url) desc;

-- select records with 'fulltext' or 'fulltext_keywords', which should be zero rows
select * from records where fulltext is not null or fulltext_keywords is not null;
```

### Includes new or updated dependencies?
YES

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-557